### PR TITLE
Add xAI live search integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 GEMINI_API_KEY=your_gemini_api_key
+XAI_API_KEY=your_xai_api_key
 SUPABASE_URL=your_supabase_url
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 SUPABASE_BUCKET_NAME=your_supabase_bucket_name

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/hacker_news",
     "crates/github",
     "crates/orchestrator",
+    "crates/xai_search",
     # "crates/arxiv",
     # "crates/scheduler", # optional
 ]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
    - `SUPABASE_ANON_KEY`: Supabase Anonymous Key (or `SUPABASE_SERVICE_ROLE_KEY`)
    - `SUPABASE_BUCKET_NAME`: Supabase Storage bucket name (e.g., `cution`)
    - `GEMINI_API_KEY`: Google Gemini API Key
+   - `XAI_API_KEY`: xAI API Key used for live search
 
 2. Build and run
    ```

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -12,3 +12,4 @@ dotenv = "0.15"
 
 github = { path = "../github" }
 hacker_news = { path = "../hacker_news" }
+xai_search = { path = "../xai_search" }

--- a/crates/orchestrator/src/main.rs
+++ b/crates/orchestrator/src/main.rs
@@ -4,9 +4,10 @@ use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
 use dotenv;
 
-// Using github and hacker_news crates
+// Using github, hacker_news and xai_search crates
 use github;
 use hacker_news;
+use xai_search;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -45,6 +46,20 @@ async fn main() -> Result<()> {
             }
             Err(e) => {
                 eprintln!("Hacker News failed: {}", e);
+                Err(e)
+            }
+        }
+    });
+
+    // Register xAI search crawler as an async task
+    crawler_tasks.spawn(async {
+        match xai_search::run_xai_search().await {
+            Ok(_) => {
+                info!("xAI search completed successfully");
+                Ok::<_, anyhow::Error>(())
+            }
+            Err(e) => {
+                eprintln!("xAI search failed: {}", e);
                 Err(e)
             }
         }

--- a/crates/xai_search/Cargo.toml
+++ b/crates/xai_search/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "xai_search"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0"
+dotenv = "0.15"
+reqwest = { version = "0.12", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+time = { version = "0.3", features = ["macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tracing = "0.1"
+

--- a/crates/xai_search/src/lib.rs
+++ b/crates/xai_search/src/lib.rs
@@ -1,0 +1,154 @@
+use anyhow::Result;
+use reqwest::Client;
+use serde::Deserialize;
+use std::env;
+use time::OffsetDateTime;
+use tracing::{info, warn};
+
+#[derive(Deserialize)]
+struct ChatCompletionResponse {
+    choices: Vec<Choice>,
+}
+
+#[derive(Deserialize)]
+struct Choice {
+    message: Message,
+}
+
+#[derive(Deserialize)]
+struct Message {
+    content: String,
+}
+
+pub struct XaiClient {
+    http_client: Client,
+    api_key: String,
+    supabase_client: SupabaseStorageClient,
+}
+
+impl XaiClient {
+    pub fn new(api_key: &str, supabase_url: &str, supabase_key: &str, supabase_bucket: &str) -> Self {
+        let http_client = Client::new();
+        let supabase_client = SupabaseStorageClient::new(supabase_url, supabase_key, supabase_bucket);
+        Self {
+            http_client,
+            api_key: api_key.to_string(),
+            supabase_client,
+        }
+    }
+
+    async fn fetch_news_digest(&self) -> Result<String> {
+        let url = "https://api.x.ai/v1/chat/completions";
+        let body = serde_json::json!({
+            "messages": [{"role": "user", "content": "Provide me a digest of world news in the last 24 hours."}],
+            "search_parameters": {"mode": "auto"},
+            "model": "grok-3-latest"
+        });
+
+        let res = self
+            .http_client
+            .post(url)
+            .header("Content-Type", "application/json")
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .json(&body)
+            .send()
+            .await?;
+
+        if !res.status().is_success() {
+            let status = res.status();
+            let text = res.text().await.unwrap_or_default();
+            anyhow::bail!("Request failed: {} - {}", status, text);
+        }
+
+        let resp: ChatCompletionResponse = res.json().await?;
+        let content = resp
+            .choices
+            .get(0)
+            .map(|c| c.message.content.clone())
+            .unwrap_or_default();
+        Ok(content)
+    }
+
+    pub async fn run(&self) -> Result<()> {
+        info!("Fetching news digest from xAI");
+        let digest = self.fetch_news_digest().await?;
+
+        if digest.is_empty() {
+            warn!("Received empty digest from xAI");
+            return Ok(());
+        }
+
+        let today = OffsetDateTime::now_utc().date().to_string();
+        let file_path = format!("{}/xai-news.md", today);
+        self
+            .supabase_client
+            .upload_file(&file_path, digest, "text/markdown")
+            .await?;
+        info!("Uploaded xAI news digest to {}", file_path);
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct SupabaseStorageClient {
+    base_url: String,
+    api_key: String,
+    bucket_name: String,
+    http_client: Client,
+}
+
+impl SupabaseStorageClient {
+    fn new(base_url: &str, api_key: &str, bucket_name: &str) -> Self {
+        SupabaseStorageClient {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            api_key: api_key.to_string(),
+            bucket_name: bucket_name.to_string(),
+            http_client: Client::new(),
+        }
+    }
+
+    async fn upload_file(&self, path: &str, content: String, content_type: &str) -> Result<()> {
+        let url = format!(
+            "{}/object/{}/{}",
+            self.base_url,
+            self.bucket_name,
+            path.trim_start_matches('/')
+        );
+
+        let res = self
+            .http_client
+            .post(&url)
+            .header("apikey", &self.api_key)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", content_type)
+            .header("x-upsert", "true")
+            .body(content)
+            .send()
+            .await?;
+
+        if res.status().is_success() {
+            Ok(())
+        } else {
+            let status = res.status();
+            let text = res.text().await.unwrap_or_default();
+            anyhow::bail!("Upload failed: {} - {}", status, text);
+        }
+    }
+}
+
+pub async fn run_xai_search() -> Result<()> {
+    let _ = dotenv::dotenv();
+    let api_key = env::var("XAI_API_KEY").expect("XAI_API_KEY must be set");
+    let supabase_url = env::var("SUPABASE_URL").expect("SUPABASE_URL must be set");
+    let supabase_key = env::var("SUPABASE_SERVICE_ROLE_KEY").expect("SUPABASE_SERVICE_ROLE_KEY must be set");
+    let supabase_bucket = env::var("SUPABASE_BUCKET_NAME").expect("SUPABASE_BUCKET_NAME must be set");
+
+    let client = XaiClient::new(
+        &api_key,
+        &format!("{}/storage/v1", supabase_url.trim_end_matches('/')),
+        &supabase_key,
+        &supabase_bucket,
+    );
+
+    client.run().await
+}


### PR DESCRIPTION
## Summary
- add new `xai_search` crate for retrieving news digests from xAI API
- integrate new crate into orchestrator
- document new `XAI_API_KEY` env variable in README and `.env.example`

## Testing
- `cargo check --offline` *(fails: no matching package named `dotenv` found)*
- `npm test` *(fails: Missing script "test")*