### PR TITLE
Create shared Supabase client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/common",
     "crates/hacker_news",
     "crates/github",
     "crates/orchestrator",

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "common"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0"
+reqwest = { version = "0.12", features = ["json"] }
+tracing = "0.1"

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod supabase_client;
+
+pub use supabase_client::SupabaseStorageClient;

--- a/crates/github/Cargo.toml
+++ b/crates/github/Cargo.toml
@@ -23,6 +23,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["fmt"] }
 dotenv = "0.15.0"
 thiserror = "2.0.1"
+common = { path = "../common" }
 
 [profile.release]
 strip = true

--- a/crates/hacker_news/Cargo.toml
+++ b/crates/hacker_news/Cargo.toml
@@ -14,3 +14,4 @@ time = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
+common = { path = "../common" }

--- a/crates/hacker_news/src/lib.rs
+++ b/crates/hacker_news/src/lib.rs
@@ -1,12 +1,10 @@
 pub mod api;
 pub mod models;
-pub mod storage;
-
 use anyhow::Result;
 use api::HackerNewsAPI;
 use models::StoryData;
 use std::env;
-use storage::SupabaseStorageClient;
+use common::SupabaseStorageClient;
 use time::OffsetDateTime;
 use tokio::task::JoinSet;
 use tracing::info;

--- a/crates/hacker_news/src/main.rs
+++ b/crates/hacker_news/src/main.rs
@@ -1,12 +1,12 @@
 mod api;
 mod models;
-mod storage;
+
 
 use anyhow::Result;
 use api::HackerNewsAPI;
 use models::StoryData;
 use std::env;
-use storage::SupabaseStorageClient;
+use common::SupabaseStorageClient;
 use time::OffsetDateTime;
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;

--- a/crates/xai_search/Cargo.toml
+++ b/crates/xai_search/Cargo.toml
@@ -12,4 +12,5 @@ serde_json = "1.0"
 time = { version = "0.3", features = ["macros"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tracing = "0.1"
+common = { path = "../common" }
 


### PR DESCRIPTION
## Summary
- add new `common` crate with `SupabaseStorageClient`
- migrate Github, Hacker News, and XAI crates to use the shared client
- remove old duplicated definitions

## Testing
- `cargo check` *(fails: Could not download crates)*