### PR TITLE
Fix EOL in storage and settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,4 +16,4 @@
         "editor.defaultFormatter": "rust-lang.rust-analyzer",
         "editor.formatOnSave": true
     }
-} 
+}

--- a/crates/hacker_news/src/storage.rs
+++ b/crates/hacker_news/src/storage.rs
@@ -55,4 +55,4 @@ impl SupabaseStorageClient {
             )
         }
     }
-} 
+}


### PR DESCRIPTION
## Summary
- ensure `.vscode/settings.json` ends with a newline
- ensure `storage.rs` ends with a newline

## Testing
- `cargo test` *(fails: Could not connect to server)*
- `cargo check --locked --offline` *(fails: no matching package named `dotenv` found)*