### PR TITLE
Gracefully skip xAI and custom site crawlers without env vars

### DIFF
--- a/crates/custom_site/src/lib.rs
+++ b/crates/custom_site/src/lib.rs
@@ -77,7 +77,13 @@ pub async fn run_custom_site_crawler() -> Result<()> {
 
     info!("Custom site crawler starting up");
 
-    let url = env::var("CUSTOM_SITE_URL").expect("CUSTOM_SITE_URL must be set");
+    let url = match env::var("CUSTOM_SITE_URL") {
+        Ok(v) => v,
+        Err(_) => {
+            warn!("CUSTOM_SITE_URL not set; skipping custom site crawler");
+            return Ok(());
+        }
+    };
     let supabase_url = env::var("SUPABASE_URL").expect("SUPABASE_URL must be set");
     let supabase_key = env::var("SUPABASE_SERVICE_ROLE_KEY").expect("SUPABASE_SERVICE_ROLE_KEY must be set");
     let supabase_bucket = env::var("SUPABASE_BUCKET_NAME").expect("SUPABASE_BUCKET_NAME must be set");

--- a/crates/xai_search/src/lib.rs
+++ b/crates/xai_search/src/lib.rs
@@ -93,7 +93,13 @@ impl XaiClient {
 
 pub async fn run_xai_search() -> Result<()> {
     let _ = dotenv::dotenv();
-    let api_key = env::var("XAI_API_KEY").expect("XAI_API_KEY must be set");
+    let api_key = match env::var("XAI_API_KEY") {
+        Ok(v) => v,
+        Err(_) => {
+            warn!("XAI_API_KEY not set; skipping xAI search");
+            return Ok(());
+        }
+    };
     let supabase_url = env::var("SUPABASE_URL").expect("SUPABASE_URL must be set");
     let supabase_key = env::var("SUPABASE_SERVICE_ROLE_KEY").expect("SUPABASE_SERVICE_ROLE_KEY must be set");
     let supabase_bucket = env::var("SUPABASE_BUCKET_NAME").expect("SUPABASE_BUCKET_NAME must be set");


### PR DESCRIPTION
## Summary
- avoid panics when `XAI_API_KEY` or `CUSTOM_SITE_URL` aren't set
- skip xAI and custom site crawlers if optional env vars are missing

## Testing
- `cargo check` *(fails: failed to get `anyhow` as dependency)*